### PR TITLE
Add SIP and SNMP keywords

### DIFF
--- a/grammars/suricata.tmLanguage
+++ b/grammars/suricata.tmLanguage
@@ -147,7 +147,7 @@
             <key>name</key>
             <string>storage.type.option.suricata</string>
             <key>match</key>
-            <string>\b(ssh_proto|ssh_software|ssh\.proto|ssh\.sofware)</string>
+            <string>\b(ssh_proto|ssh_software|ssh\.proto|ssh\.software)</string>
         </dict>
         <!-- JA3 Keywords 
         https://suricata.readthedocs.io/en/latest/rules/ja3-keywords.html -->

--- a/grammars/suricata.tmLanguage
+++ b/grammars/suricata.tmLanguage
@@ -210,6 +210,30 @@
         app-layer-event:krb5.weak_encryption
         app-layer-event:krb5.malformed_data
         -->
+        <!-- SNMP Keywords
+        https://suricata.readthedocs.io/en/latest/rules/snmp-keywords.html -->
+        <dict>
+            <key>name</key>
+            <string>storage.type.option.suricata</string>
+            <key>match</key>
+            <string>\b(snmp\.version|snmp\.pdu_type)</string>
+        </dict>
+        <!-- sticky buffers -->
+        <dict>
+            <key>name</key>
+            <string>storage.type.option.suricata</string>
+            <key>match</key>
+            <string>\b(snmp\.community)</string>
+        </dict>
+        <!-- SIP Keywords
+        https://suricata.readthedocs.io/en/latest/rules/sip-keywords.html -->
+        <!-- sticky buffers -->
+        <dict>
+            <key>name</key>
+            <string>storage.type.option.suricata</string>
+            <key>match</key>
+            <string>\b(sip\.method|sip\.uri|sip\.request_line|sip\.stat_code|sip\.stat_msg|sip\.response_line|sip\.protocol)</string>
+        </dict>
         <!-- Generic App Layer Keywords 
         https://suricata.readthedocs.io/en/latest/rules/app-layer.html -->
         <dict>
@@ -341,7 +365,7 @@
             <key>name</key>
             <string>keyword.other.protocol.suricata</string>
             <key>match</key>
-            <string>\b(tcp|udp|icmp|ip|http|ftp\-data|ftp|tls|smb|dns|dcerpc|ssh|smtp|imap|msn|modbus|dnp3|enip|nfs|ikev2|krb5|ntp|dhcp)\b</string>
+            <string>\b(tcp|udp|icmp|ip|http|ftp\-data|ftp|tls|smb|dns|dcerpc|ssh|smtp|imap|msn|modbus|dnp3|enip|nfs|ikev2|krb5|ntp|dhcp|sip|snmp)\b</string>
         </dict>
         <!-- IPv4 Addresses -->
         <dict>

--- a/grammars/suricata.tmLanguage
+++ b/grammars/suricata.tmLanguage
@@ -61,7 +61,7 @@
             <key>name</key>
             <string>storage.type.option.suricata</string>
             <key>match</key>
-            <string>\b(fstrip_whitespace|compress_whitespace|to_sha256|to_md5|to_sha1)</string>
+            <string>\b(strip_whitespace|compress_whitespace|to_sha256|to_md5|to_sha1)</string>
         </dict>
         <!-- Prefiltering keywords -->
         <!-- https://suricata.readthedocs.io/en/latest/rules/prefilter-keywords.html -->


### PR DESCRIPTION
This PR introduces new keywords for rules acting on SNMP and SIP data according to:
- https://suricata.readthedocs.io/en/latest/rules/snmp-keywords.html
- https://suricata.readthedocs.io/en/latest/rules/sip-keywords.html

It also fixes some typos.