### PR TITLE
support both `lua` and `luajit` keywords

### DIFF
--- a/grammars/suricata.tmLanguage
+++ b/grammars/suricata.tmLanguage
@@ -286,7 +286,7 @@
             <key>name</key>
             <string>storage.type.option.suricata</string>
             <key>match</key>
-            <string>\b(lua)</string>
+	    <string>\b(lua|luajit)\b</string>
         </dict>
 
         <!-- Miscellaneous -->


### PR DESCRIPTION
The code says `luajit` is also a keyword [1], and it works!

[1] https://github.com/OISF/suricata/blob/master/src/detect-lua.c#L77