### PR TITLE
Add Suricata 6 app-layer keywords

### DIFF
--- a/grammars/suricata.tmLanguage
+++ b/grammars/suricata.tmLanguage
@@ -93,14 +93,14 @@
             <key>name</key>
             <string>storage.type.option.suricata</string>
             <key>match</key>
-            <string>\b(http_uri|http_raw_uri|http_method|http_client_body|http_header|http_raw_header|http_cookie|http_user_agent|http_host|http_raw_host|http_stat_msg|http_stat_code|http_server_body|http\.server|http\.location)</string>
+            <string>\b(http[._]uri|http\.uri\.raw|http_raw_uri|http[._]method|http_client_body|http[._]header|http\.header\.raw|http_raw_header|http_cookie|http[._]user_agent|http[._]host|http\.host\.raw|http_raw_host|http\.server_body|http[._]stat_msg|http[._]stat_code|http_server_body|http\.server|http\.location)</string>
         </dict>
         <!-- sticky-buffers -->
         <dict>
             <key>name</key>
             <string>storage.type.option.suricata</string>
             <key>match</key>
-            <string>\b(http_request_line|http_accept|http_accept_lang|http_accept_enc|http_referer|http_connection|http_content_type|http_content_len|http_start|http_protocol|http_header_names|http_response_line|file_data|http\.protocol)</string>
+            <string>\b(http[._]request_line|http\.request_body|http[._]accept|http[._]accept_lang|http[._]accept_enc|http[._]referer|http[._]connection|http[._]content_type|http[._]content_len|http[._]start|http[._]protocol|http[._]header_names|http[._]response_line|file[._]data|http\.protocol)</string>
         </dict>
         <!-- File keywords -->
         <!-- https://suricata.readthedocs.io/en/latest/rules/file-keywords.html -->

--- a/grammars/suricata.tmLanguage
+++ b/grammars/suricata.tmLanguage
@@ -263,6 +263,21 @@
             <key>match</key>
             <string>\b(mqtt\.connect\.clientid|mqtt\.connect\.password|mqtt\.connect\.username|mqtt\.connect\.willmessage|mqtt\.connect\.willtopic|mqtt\.publish\.message|mqtt\.publish\.topic|mqtt\.subscribe\.topic|mqtt\.unsubscribe\.topic)</string>
         </dict>
+         <!-- HTTP2 Keywords
+        https://suricata.readthedocs.io/en/latest/rules/http2-keywords.html -->
+        <dict>
+            <key>name</key>
+            <string>storage.type.option.suricata</string>
+            <key>match</key>
+            <string>\b(http2\.frametype|http2\.errorcode|http2\.priority|http2\.window|http2\.size_update|http2\.settings)</string>
+        </dict>
+        <!-- sticky buffers -->
+        <dict>
+            <key>name</key>
+            <string>storage.type.option.suricata</string>
+            <key>match</key>
+            <string>\b(http2\.header(_name)?)</string>
+        </dict>
         <!-- Generic App Layer Keywords 
         https://suricata.readthedocs.io/en/latest/rules/app-layer.html -->
         <dict>

--- a/grammars/suricata.tmLanguage
+++ b/grammars/suricata.tmLanguage
@@ -2,7 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <!-- Documentation includes all changes to https://github.com/OISF/suricata/commit/65039d4accf2133c64bd2ff3223f5be19dd9daa9 -->
 	<key>fileTypes</key>
 	<array>
 		<string>suricata</string>

--- a/grammars/suricata.tmLanguage
+++ b/grammars/suricata.tmLanguage
@@ -233,6 +233,36 @@
             <key>match</key>
             <string>\b(sip\.method|sip\.uri|sip\.request_line|sip\.stat_code|sip\.stat_msg|sip\.response_line|sip\.protocol)</string>
         </dict>
+        <!-- RFB Keywords
+        https://suricata.readthedocs.io/en/latest/rules/rfb-keywords.html -->
+        <dict>
+            <key>name</key>
+            <string>storage.type.option.suricata</string>
+            <key>match</key>
+            <string>\b(rfb\.secresult|rfb\.sectype)</string>
+        </dict>
+        <!-- sticky buffers -->
+        <dict>
+            <key>name</key>
+            <string>storage.type.option.suricata</string>
+            <key>match</key>
+            <string>\b(rfb\.name)</string>
+        </dict>
+        <!-- MQTT Keywords
+        https://suricata.readthedocs.io/en/latest/rules/mqtt-keywords.html -->
+        <dict>
+            <key>name</key>
+            <string>storage.type.option.suricata</string>
+            <key>match</key>
+            <string>\b(mqtt\.protocol_version|mqtt\.type|mqtt\.flags|mqtt\.connect\.flags|mqtt\.reason_code|mqtt\.qos|mqtt\.connack\.session_present)</string>
+        </dict>
+        <!-- sticky buffers -->
+        <dict>
+            <key>name</key>
+            <string>storage.type.option.suricata</string>
+            <key>match</key>
+            <string>\b(mqtt\.connect\.clientid|mqtt\.connect\.password|mqtt\.connect\.username|mqtt\.connect\.willmessage|mqtt\.connect\.willtopic|mqtt\.publish\.message|mqtt\.publish\.topic|mqtt\.subscribe\.topic|mqtt\.unsubscribe\.topic)</string>
+        </dict>
         <!-- Generic App Layer Keywords 
         https://suricata.readthedocs.io/en/latest/rules/app-layer.html -->
         <dict>


### PR DESCRIPTION
Suricata 6 will add support for some more appication layer protocols and will hence add keywords for detection. This PR adds highlighting for the keywords for the following new protocols:
- HTTP2
- RFB
- MQTT

It also adds support for alternative styles of HTTP keywords, e.g. `http.stat_code` vs. `http_stat_code`.